### PR TITLE
ci: exclude badge-studio from rsync delete

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,5 +38,6 @@ jobs:
             --exclude='*.backup.*' \
             --exclude='New website' \
             --exclude='sightlines' \
+            --exclude='badge-studio' \
             -e "ssh -i ~/.ssh/deploy_key" \
             ./ "$VPS_USER@$VPS_HOST:$DEPLOY_PATH/"


### PR DESCRIPTION
## Summary

- Adds `--exclude='badge-studio'` to the rsync command in the deploy workflow
- badge-studio is deployed independently to `/opt/ghost/sites/dynamicskillset.com/badge-studio/` via its own CI/CD pipeline
- Without this exclusion, every push to the main site would wipe the badge-studio files due to `--delete`

## No functional change to the main site

This only affects which directories rsync leaves untouched. The main site files are unaffected.